### PR TITLE
Django 1.7 get_verbose_name

### DIFF
--- a/couchdbkit/ext/django/schema.py
+++ b/couchdbkit/ext/django/schema.py
@@ -20,8 +20,12 @@ add possibility to a document to register itself in CouchdbkitHandler
 import re
 import sys
 
+try:
+    from django.db.models.options import get_verbose_name
+except ImportError:
+    from django.utils.text import camel_case_to_spaces as get_verbose_name
+
 from django.conf import settings
-from django.db.models.options import get_verbose_name
 from django.utils.translation import activate, deactivate_all, get_language, \
 string_concat
 from django.utils.encoding import smart_str, force_unicode


### PR DESCRIPTION
This uses the new utils text package as a way to format a name to the standard format.

In django 1.7 the get_verbose_name util doesn't exist anymore.
